### PR TITLE
Update `ip` to 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/non-private-ip.git"
   },
   "dependencies": {
-    "ip": "~0.3.2"
+    "ip": "^1.1.5"
   },
   "devDependencies": {
     "tape": "~3.0.3"


### PR DESCRIPTION
The latest ip package supports IPv4-mapped IPv6 addresses, whereas 0.3.3 did not.

I encountered this problem in React Native (apparently I received an IPv4-mapped IPv6 address from somewhere), and traced it back to here.

I suppose this commit would mean a new version `non-private-ip@2.0.0`. (Also, would appreciate a new patch version of scuttlebot)

PS: it's coming from a `patch-1` branch, but I promise I cloned this and tested it with `ip@1.1.5` as dependency, tests passed.