### PR TITLE
merge from staltz/non-private-ip

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,61 +1,108 @@
-var os = require('os')
-var ip = require('ip')
-//pick the first reasonable looking host.
-//this should *just work* when running on a vps.
+var os = require('os');
+var ip = require('ip');
+// pick the first reasonable looking host.
+// this should *just work* when running on a vps.
 
-var isPrivate = ip.isPrivate
+var isPrivate = ip.isPrivate;
 
-function isNonPrivate (e) {
-  return !isPrivate(e)
+function isNonPrivate(e) {
+  return !isPrivate(e);
 }
 
+var address = (module.exports = function address(inter, filter) {
+  inter = inter || os.networkInterfaces();
+  filter = filter || isNonPrivate;
+  var score = 0;
+  var candidate = undefined;
+  for (var k in inter) {
+    for (var i in inter[k]) {
+      var e = inter[k][i];
 
-var address = module.exports = function (inter, filter) {
-  inter = inter || os.networkInterfaces()
-  filter = filter || isNonPrivate
-  for(var k in inter) {
-    for(var i in inter[k]) {
-      var e = inter[k][i]
-      // find a reasonable looking address
-      if(!e.internal && filter(e.address, e))
-          return e.address
+      // Must not be loopback:
+      if (e.internal) continue;
+      // Must pass our filter:
+      if (!filter(e.address, e)) continue;
+
+      // Prioritize IPv4 wlan:
+      if (k.startsWith('wl') && e.family === 'IPv4' && score < 8) {
+        score = 8;
+        candidate = e.address;
+      }
+      // Prioritize IPv4 ethernet:
+      else if (k.startsWith('en') && e.family === 'IPv4' && score < 7) {
+        score = 7;
+        candidate = e.address;
+      }
+      // Prioritize IPv4 OLD ethernet:
+      else if (k.startsWith('eth') && e.family === 'IPv4' && score < 6) {
+        score = 6;
+        candidate = e.address;
+      }
+      // Prioritize wlan:
+      else if (k.startsWith('wl') && e.family === 'IPv6' && score < 5) {
+        score = 5;
+        candidate = e.address + '%' + k;
+      }
+      // Prioritize ethernet:
+      else if (k.startsWith('en') && e.family === 'IPv6' && score < 4) {
+        score = 4;
+        candidate = e.address + '%' + k;
+      }
+      // Prioritize OLD ethernet:
+      else if (k.startsWith('eth') && e.family === 'IPv6' && score < 3) {
+        score = 3;
+        candidate = e.address + '%' + k;
+      }
+      // Prioritize IPv4 tunnels (VPN):
+      else if (k.startsWith('tun') && e.family === 'IPv4' && score < 2) {
+        score = 2;
+        candidate = e.address;
+      }
+      // Prioritize tunnels (VPN):
+      else if (k.startsWith('tun') && e.family === 'IPv6' && score < 1) {
+        score = 1;
+        candidate = e.address + '%' + k;
+      }
     }
   }
+  return candidate;
+});
+
+function isV4(e) {
+  return e.family === 'IPv4';
 }
 
-function isV4 (e) {
-  return e.family === 'IPv4'
+function isV6(e) {
+  return e.family === 'IPv6';
 }
 
-function isV6 (e) {
-  return e.family === 'IPv6'
-}
+var _private = (module.exports.private = function _private(inter) {
+  return address(inter, isPrivate);
+});
 
-var _private = module.exports.private = function (inter) {
-  return address(inter, isPrivate)
-}
+module.exports.v4 = address(null, function v4(addr, e) {
+  return isV4(e) && isNonPrivate(addr);
+});
 
-module.exports.v4 = address(null, function (addr, e) {
-  return isV4(e) && isNonPrivate(addr)
-})
+module.exports.v6 = address(null, function v6(addr, e) {
+  return isV6(e) && isNonPrivate(addr);
+});
 
-module.exports.v6 = address(null, function (addr, e) {
-  return isV6(e) && isNonPrivate(addr)
-})
+_private.v4 = address(null, function privateV4(addr, e) {
+  return isV4(e) && isPrivate(addr);
+});
 
-_private.v4 = address(null, function (addr, e) {
-  return isV4(e) && isPrivate(addr)
-})
-
-_private.v6 = address(null, function (addr, e) {
-  return isV6(e) && isPrivate(addr)
-})
+_private.v6 = address(null, function privateV6(addr, e) {
+  return isV6(e) && isPrivate(addr);
+});
 
 module.exports.all = {
   public: {
-    v4: module.exports.v4, v6: module.exports.v6
+    v4: module.exports.v4,
+    v6: module.exports.v6,
   },
   private: {
-    v4: _private.v4, v6: _private.v6
-  }
-}
+    v4: _private.v4,
+    v6: _private.v6,
+  },
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,59 +1,43 @@
-var nonPrivate = require('../')
-var tape = require('tape')
+var nonPrivate = require('../');
+var tape = require('tape');
 
-var vps = { lo:
-   [ { address: '127.0.0.1',
-       family: 'IPv4',
-       internal: true },
-     { address: '::1',
-       family: 'IPv6',
-       internal: true } ],
-  eth0:
-   [ { address: '176.58.117.63',
-       family: 'IPv4',
-       internal: false },
-     { address: '2a01:7e00::f03c:91ff:fe56:9728',
-       family: 'IPv6',
-       internal: false },
-     { address: 'fe80::f03c:91ff:fe56:9728',
-       family: 'IPv6',
-       internal: false } ] }
+var vps = {
+  lo: [
+    {address: '127.0.0.1', family: 'IPv4', internal: true},
+    {address: '::1', family: 'IPv6', internal: true},
+  ],
+  eth0: [
+    {address: '176.58.117.63', family: 'IPv4', internal: false},
+    {
+      address: '2a01:7e00::f03c:91ff:fe56:9728',
+      family: 'IPv6',
+      internal: false,
+    },
+    {address: 'fe80::f03c:91ff:fe56:9728', family: 'IPv6', internal: false},
+  ],
+};
 
-
-var laptop = { lo:
-   [ { address: '127.0.0.1',
-       family: 'IPv4',
-       internal: true },
-     { address: '::1',
-       family: 'IPv6',
-       internal: true } ],
-  enp0s25:
-   [ { address: '192.168.1.41',
-       family: 'IPv4',
-       internal: false },
-     { address: 'fe80::f2de:f1ff:fed9:5c68',
-       family: 'IPv6',
-       internal: false },
-     { address: 'fe80::1ae1:738c:3004:75e5',
-       family: 'IPv6',
-       internal: false } ],
-  wlp3s0:
-   [ { address: '192.168.1.61',
-       family: 'IPv4',
-       internal: false },
-     { address: 'fe80::76e5:bff:fea6:151c',
-       family: 'IPv6',
-       internal: false },
-     { address: 'fe80::5a4:f331:d041:9f71',
-       family: 'IPv6',
-       internal: false } ] }
+var laptop = {
+  lo: [
+    {address: '127.0.0.1', family: 'IPv4', internal: true},
+    {address: '::1', family: 'IPv6', internal: true},
+  ],
+  enp0s25: [
+    {address: '192.168.1.41', family: 'IPv4', internal: false},
+    {address: 'fe80::f2de:f1ff:fed9:5c68', family: 'IPv6', internal: false},
+    {address: 'fe80::1ae1:738c:3004:75e5', family: 'IPv6', internal: false},
+  ],
+  wlp3s0: [
+    {address: '192.168.1.61', family: 'IPv4', internal: false},
+    {address: 'fe80::76e5:bff:fea6:151c', family: 'IPv6', internal: false},
+    {address: 'fe80::5a4:f331:d041:9f71', family: 'IPv6', internal: false},
+  ],
+};
 
 tape('simple', function (t) {
-
-  t.equal(nonPrivate(vps), '176.58.117.63')
-  t.equal(nonPrivate(laptop), undefined)
-  t.equal(nonPrivate.private(vps), 'fe80::f03c:91ff:fe56:9728')
-  t.equal(nonPrivate.private(laptop), '192.168.1.41')
-  t.end()
-
-})
+  t.equal(nonPrivate(vps), '176.58.117.63');
+  t.equal(nonPrivate(laptop), undefined);
+  t.equal(nonPrivate.private(vps), 'fe80::f03c:91ff:fe56:9728%eth0');
+  t.equal(nonPrivate.private(laptop), '192.168.1.61');
+  t.end();
+});


### PR DESCRIPTION
Dominic just transferred this repo to ssbc on my request.

I've been maintaining a fork of this module at https://github.com/staltz/non-private-ip/tree/fork and published it to npm as `non-private-ip-android`, the reason for that is because when the `private()` API of this module is used, I would like to get the best available IP address across all network interfaces, and usually the "best" means an IPv4 on WLAN, avoiding some IPv4 such as "rmnet" which (I think) is the Mobile ISP's network address, and that one was always the wrong choice.

So I developed a score system that prioritizes those, but there's others. The ranking order is: WLAN IPv4 > Ethernet IPv4 > WLAN IPv6 > Ethernet IPv6 > VPN IPv4 > VPN IPv6

Apart from that, I also added support for IPv6 scopes, such as `%eth0` in `fe80::f03c:91ff:fe56:9728%eth0`.

Most importantly, I've been running `non-private-ip-android` in production in Manyverse on Android, iOS, and Desktop, so I am positive that the implementation is good, and that's why I'm making this PR, so we can make it the next official `non-private-ip`.