### PR TITLE
allow getting details object as return

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # non-private-ip
 
 Picks the first reasonable looking IP address from network interfaces.
-This should *just work* when running on a VPS, but also provides `private` APIs
+This should _just work_ when running on a VPS, but also provides `private` APIs
 so that when running in LAN you get the first reasonable looking LAN IP address.
 
 More info: http://en.wikipedia.org/wiki/Private_network
@@ -12,6 +12,18 @@ probably does. This just returns the first address, which will probably be IPv4.
 This module is based on the ["ip" module](https://www.npmjs.com/package/ip).
 
 ## API
+
+The main export is a function `nonPrivateIP(interfaces, filter, details)` where:
+
+- `interfaces` is either `null` or a mock of `os.networkInterfaces()`, typically
+  **this should be `null`**
+- `filter` is a **function** of the shape `(address, details) => boolean` where
+  `address` is the IP address as a string, and `details` is the whole object
+  with additional fields, e.g. `address`, `netmask`, `family`, `mac`, `cidr`,
+  etc
+- `details` is a boolean that controls whether you want the return of the
+  function to be just the IP address as a string (`false`, this is the
+  **default**) or the whole object with additional fields (`true`)
 
 ```js
 // On a VPS:

--- a/index.js
+++ b/index.js
@@ -9,13 +9,14 @@ function isNonPrivate(e) {
   return !isPrivate(e)
 }
 
-function address(inter, filter) {
+function address(inter, filter, details) {
   inter = inter || os.networkInterfaces()
   filter = filter || isNonPrivate
   let score = 0
   let candidate = undefined
   for (const k of Object.keys(inter)) {
     for (const e of inter[k]) {
+      e.interface = k
       // Must not be loopback:
       if (e.internal) continue
       // Must pass our filter:
@@ -24,42 +25,42 @@ function address(inter, filter) {
       // Prioritize IPv4 wlan:
       if (k.startsWith('wl') && e.family === 'IPv4' && score < 8) {
         score = 8
-        candidate = e.address
+        candidate = details ? e : e.address
       }
       // Prioritize IPv4 ethernet:
       else if (k.startsWith('en') && e.family === 'IPv4' && score < 7) {
         score = 7
-        candidate = e.address
+        candidate = details ? e : e.address
       }
       // Prioritize IPv4 OLD ethernet:
       else if (k.startsWith('eth') && e.family === 'IPv4' && score < 6) {
         score = 6
-        candidate = e.address
+        candidate = details ? e : e.address
       }
       // Prioritize wlan:
       else if (k.startsWith('wl') && e.family === 'IPv6' && score < 5) {
         score = 5
-        candidate = e.address + '%' + k
+        candidate = details ? e : e.address + '%' + k
       }
       // Prioritize ethernet:
       else if (k.startsWith('en') && e.family === 'IPv6' && score < 4) {
         score = 4
-        candidate = e.address + '%' + k
+        candidate = details ? e : e.address + '%' + k
       }
       // Prioritize OLD ethernet:
       else if (k.startsWith('eth') && e.family === 'IPv6' && score < 3) {
         score = 3
-        candidate = e.address + '%' + k
+        candidate = details ? e : e.address + '%' + k
       }
       // Prioritize IPv4 tunnels (VPN):
       else if (k.startsWith('tun') && e.family === 'IPv4' && score < 2) {
         score = 2
-        candidate = e.address
+        candidate = details ? e : e.address
       }
       // Prioritize tunnels (VPN):
       else if (k.startsWith('tun') && e.family === 'IPv6' && score < 1) {
         score = 1
-        candidate = e.address + '%' + k
+        candidate = details ? e : e.address + '%' + k
       }
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 const tape = require('tape')
 const nonPrivate = require('../')
+const ip = require('ip')
 
 const vps = {
   lo: [
@@ -39,5 +40,15 @@ tape('simple', function (t) {
   t.equal(nonPrivate(laptop), undefined)
   t.equal(nonPrivate.private(vps), 'fe80::f03c:91ff:fe56:9728%eth0')
   t.equal(nonPrivate.private(laptop), '192.168.1.61')
+  t.end()
+})
+
+tape('details', function (t) {
+  t.deepEqual(nonPrivate(laptop, ip.isPrivate, true), {
+    address: '192.168.1.61',
+    family: 'IPv4',
+    internal: false,
+    interface: 'wlp3s0',
+  })
   t.end()
 })


### PR DESCRIPTION
## Context

I'm still working on fixing UDP outbound broadcasts on Windows: https://gitlab.com/staltz/manyverse/-/issues/1694

## Problem

Given an IP address returned from `non-private-ip`, I need to also get the `netmask` associated with it, so I can calculate the broadcast IP address (e.g. using `ip`'s [subnet()](https://github.com/indutny/node-ip/blob/43e442366bf5a93493c8c4c36736f87d675b0c3d/lib/ip.js#L178) function).

## Solution

This PR adds an argument so that the return object can be the whole `e` instead of `e.address`.

Additionally, the `e` object also contains the network interface "name", because it's sometimes necessary to build IPv6 `%` scopes.