### PR TITLE
use IPv6 scopeid if it's available

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -14,6 +14,17 @@ function address(inter, filter, details) {
   filter = filter || isNonPrivate
   let score = 0
   let candidate = undefined
+  function setCandidate(e) {
+    if (details) {
+      candidate = e
+    } else {
+      if (e.family === 'IPv6') {
+        candidate = e.address + '%' + (e.scopeid || e.interface)
+      } else {
+        candidate = e.address
+      }
+    }
+  }
   for (const k of Object.keys(inter)) {
     for (const e of inter[k]) {
       e.interface = k
@@ -25,42 +36,42 @@ function address(inter, filter, details) {
       // Prioritize IPv4 wlan:
       if (k.startsWith('wl') && e.family === 'IPv4' && score < 8) {
         score = 8
-        candidate = details ? e : e.address
+        setCandidate(e)
       }
       // Prioritize IPv4 ethernet:
       else if (k.startsWith('en') && e.family === 'IPv4' && score < 7) {
         score = 7
-        candidate = details ? e : e.address
+        setCandidate(e)
       }
       // Prioritize IPv4 OLD ethernet:
       else if (k.startsWith('eth') && e.family === 'IPv4' && score < 6) {
         score = 6
-        candidate = details ? e : e.address
+        setCandidate(e)
       }
       // Prioritize wlan:
       else if (k.startsWith('wl') && e.family === 'IPv6' && score < 5) {
         score = 5
-        candidate = details ? e : e.address + '%' + k
+        setCandidate(e)
       }
       // Prioritize ethernet:
       else if (k.startsWith('en') && e.family === 'IPv6' && score < 4) {
         score = 4
-        candidate = details ? e : e.address + '%' + k
+        setCandidate(e)
       }
       // Prioritize OLD ethernet:
       else if (k.startsWith('eth') && e.family === 'IPv6' && score < 3) {
         score = 3
-        candidate = details ? e : e.address + '%' + k
+        setCandidate(e)
       }
       // Prioritize IPv4 tunnels (VPN):
       else if (k.startsWith('tun') && e.family === 'IPv4' && score < 2) {
         score = 2
-        candidate = details ? e : e.address
+        setCandidate(e)
       }
       // Prioritize tunnels (VPN):
       else if (k.startsWith('tun') && e.family === 'IPv6' && score < 1) {
         score = 1
-        candidate = details ? e : e.address + '%' + k
+        setCandidate(e)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "ip": "^1.1.5"
   },
   "devDependencies": {
-    "tape": "~3.0.3"
+    "tap-spec": "^5.0.0",
+    "tape": "~5.4.1"
   },
   "scripts": {
     "prepublish": "npm ls &&  npm test",
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape test/index.js | tap-spec"
   },
   "bin": "./bin.js",
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,27 @@ const vps = {
   ],
 }
 
+const vps2 = {
+  lo: [
+    { address: '127.0.0.1', family: 'IPv4', internal: true },
+    { address: '::1', family: 'IPv6', internal: true },
+  ],
+  eth0: [
+    { address: '176.58.117.63', family: 'IPv4', internal: false },
+    {
+      address: '2a01:7e00::f03c:91ff:fe56:9728',
+      family: 'IPv6',
+      internal: false,
+    },
+    {
+      address: 'fe80::f03c:91ff:fe56:9728',
+      family: 'IPv6',
+      internal: false,
+      scopeid: 4,
+    },
+  ],
+}
+
 const laptop = {
   lo: [
     { address: '127.0.0.1', family: 'IPv4', internal: true },
@@ -39,6 +60,7 @@ tape('simple', function (t) {
   t.equal(nonPrivate(vps), '176.58.117.63')
   t.equal(nonPrivate(laptop), undefined)
   t.equal(nonPrivate.private(vps), 'fe80::f03c:91ff:fe56:9728%eth0')
+  t.equal(nonPrivate.private(vps2), 'fe80::f03c:91ff:fe56:9728%4')
   t.equal(nonPrivate.private(laptop), '192.168.1.61')
   t.end()
 })


### PR DESCRIPTION
## Context

IPv6 addresses can have a scope `%` suffix for example `fe80::6d6:aaff:fe87:179c%wlan0` but there are two ways to use that: (1) with the interface name e.g. `%wlan0` or (2) a number ID given by the operating system e.g. `%4`.

The second method is sometimes given by the interface details object, like:

```js
{
  address: 'fe80::f927:7648:edf4:bc96',
  netmask: 'ffff:ffff:ffff:ffff::',
  family: 'IPv6',
  mac: '68:ec:c5:08:d2:ac',
  internal: false,
  cidr: 'fe80::f927:7648:edf4:bc96/64',
  scopeid: 4  // <----------------------------------
}
```

## Problem

The implementation was always adding the scope as the interface name. This could be problematic on Windows where the interface name is something like `Local Area Connection` so the scope `%Local Area Connection` wouldn't work.

## Solution

Prioritize using `details.scopeid` if it exists, otherwise fall back to interface name.

Also updates test toolkit and enables tests in CI.