### PR TITLE
support Windows interface names

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,45 +33,67 @@ function address(inter, filter, details) {
       // Must pass our filter:
       if (!filter(e.address, e)) continue
 
-      // Prioritize IPv4 wlan:
-      if (k.startsWith('wl') && e.family === 'IPv4' && score < 8) {
-        score = 8
-        setCandidate(e)
-      }
-      // Prioritize IPv4 ethernet:
-      else if (k.startsWith('en') && e.family === 'IPv4' && score < 7) {
-        score = 7
-        setCandidate(e)
-      }
-      // Prioritize IPv4 OLD ethernet:
-      else if (k.startsWith('eth') && e.family === 'IPv4' && score < 6) {
-        score = 6
-        setCandidate(e)
-      }
-      // Prioritize wlan:
-      else if (k.startsWith('wl') && e.family === 'IPv6' && score < 5) {
-        score = 5
-        setCandidate(e)
-      }
-      // Prioritize ethernet:
-      else if (k.startsWith('en') && e.family === 'IPv6' && score < 4) {
-        score = 4
-        setCandidate(e)
-      }
-      // Prioritize OLD ethernet:
-      else if (k.startsWith('eth') && e.family === 'IPv6' && score < 3) {
-        score = 3
-        setCandidate(e)
-      }
-      // Prioritize IPv4 tunnels (VPN):
-      else if (k.startsWith('tun') && e.family === 'IPv4' && score < 2) {
-        score = 2
-        setCandidate(e)
-      }
-      // Prioritize tunnels (VPN):
-      else if (k.startsWith('tun') && e.family === 'IPv6' && score < 1) {
-        score = 1
-        setCandidate(e)
+      if (process.platform === 'win32') {
+        if (k.includes('Wi-Fi') && e.family === 'IPv4' && score < 4) {
+          score = 4
+          setCandidate(e)
+        } else if (k.includes('Ethernet') && e.family === 'IPv4' && score < 3) {
+          score = 3
+          setCandidate(e)
+        } else if (k.includes('Wi-Fi') && e.family === 'IPv6' && score < 2) {
+          score = 2
+          setCandidate(e)
+        } else if (k.includes('Ethernet') && e.family === 'IPv6' && score < 1) {
+          score = 1
+          setCandidate(e)
+        } else if (score === 0) {
+          setCandidate(e)
+        }
+      } else {
+        // Prioritize IPv4 wlan:
+        if (k.startsWith('wl') && e.family === 'IPv4' && score < 8) {
+          score = 8
+          setCandidate(e)
+        }
+        // Prioritize IPv4 ethernet:
+        else if (k.startsWith('en') && e.family === 'IPv4' && score < 7) {
+          score = 7
+          setCandidate(e)
+        }
+        // Prioritize IPv4 OLD ethernet:
+        else if (k.startsWith('eth') && e.family === 'IPv4' && score < 6) {
+          score = 6
+          setCandidate(e)
+        }
+        // Prioritize wlan:
+        else if (k.startsWith('wl') && e.family === 'IPv6' && score < 5) {
+          score = 5
+          setCandidate(e)
+        }
+        // Prioritize ethernet:
+        else if (k.startsWith('en') && e.family === 'IPv6' && score < 4) {
+          score = 4
+          setCandidate(e)
+        }
+        // Prioritize OLD ethernet:
+        else if (k.startsWith('eth') && e.family === 'IPv6' && score < 3) {
+          score = 3
+          setCandidate(e)
+        }
+        // Prioritize IPv4 tunnels (VPN):
+        else if (k.startsWith('tun') && e.family === 'IPv4' && score < 2) {
+          score = 2
+          setCandidate(e)
+        }
+        // Prioritize tunnels (VPN):
+        else if (k.startsWith('tun') && e.family === 'IPv6' && score < 1) {
+          score = 1
+          setCandidate(e)
+        }
+        // Allow everything else
+        else if (score === 0) {
+          setCandidate(e)
+        }
       }
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,11 @@ const laptop = {
   ],
 }
 
+const windows = {
+  Ethernet: [{ address: '192.168.1.41', family: 'IPv4', internal: false }],
+  'Wi-Fi': [{ address: '192.168.1.42', family: 'IPv4', internal: false }],
+}
+
 tape('simple', function (t) {
   t.equal(nonPrivate(vps), '176.58.117.63')
   t.equal(nonPrivate(laptop), undefined)
@@ -71,6 +76,21 @@ tape('details', function (t) {
     family: 'IPv4',
     internal: false,
     interface: 'wlp3s0',
+  })
+  t.end()
+})
+
+tape('windows', function (t) {
+  const previous = process.platform
+  Object.defineProperty(process, 'platform', {
+    value: 'win32',
+  })
+
+  t.equal(nonPrivate(windows), undefined, 'non private on windows')
+  t.equal(nonPrivate.private(windows), '192.168.1.42', 'private on windows')
+
+  Object.defineProperty(process, 'platform', {
+    value: previous,
   })
   t.end()
 })


### PR DESCRIPTION
## Context

Turns out that my [PR for dgram-broadcast](https://github.com/ssbc/dgram-broadcast/pull/9) was the wrong solution to fix UDP outbound broadcasts on Windows. (See https://gitlab.com/staltz/manyverse/-/issues/1694 in Manyverse). This PR is the real fix, I made sure by modifying `non-private-ip`'s source code in Manyverse on Windows and it fixed the whole issue.

## Problem

This library was assuming that network interface names were always Unix style, e.g. `en`, `wlan`, etc. That's not the case on **Windows**, LOL. On Windows you get stuff like this when you call `os.networkInterfaces()`:

```js
{
  "Wi-Fi": {
    address: "192.168.0.200",
    // ...
  },
  "Loopback Pseudo-Interface 1": {
    address: "127.0.0.1",
    // ...
  }
}
```

## Solution

Take into account `process.platform` and use Windows-specific rules.

1st test :x:, 2nd solution :heavy_check_mark: 